### PR TITLE
Refine app structure with MARK sections

### DIFF
--- a/SocioInfonavitApp/SocioInfonavitApp/App/AppCoordinator.swift
+++ b/SocioInfonavitApp/SocioInfonavitApp/App/AppCoordinator.swift
@@ -10,48 +10,59 @@ import FirebaseAuth
 import SwiftUI
 
 final class AppCoordinator: ObservableObject {
-    @Published var rootView: AnyView = AnyView(EmptyView())
-    @StateObject private var homeViewModel = HomeViewModel()
-    
-    init() {
-        start()
-    }
-    
-    func start() {
-        if Auth.auth().currentUser != nil {
-            showHome()
-        } else {
-            showLauncher()
-        }
-    }
-    
-    private func showLauncher() {
-        rootView = AnyView(LaunchScreenView())
-    }
-    
-    private func showHome() {
-        let view = HomeView(viewModel: homeViewModel) 
-            .environmentObject(self)
-        rootView = AnyView(view)
-    }
 
-    
-    func navigateToHome() {
-        showHome()
+  // MARK: - Properties
+
+  @Published var rootView: AnyView = AnyView(EmptyView())
+  @StateObject private var homeViewModel = HomeViewModel()
+
+  // MARK: - Initialization
+
+  init() {
+    start()
+  }
+
+  // MARK: - Lifecycle
+
+  func start() {
+    if Auth.auth().currentUser != nil {
+      showHome()
+    } else {
+      showLauncher()
     }
-    
-    func logout() {
-        do {
-            try Auth.auth().signOut()
-            showLauncher()
-        } catch {
-            AppErrorManager.shared.present(error: .server(message: "Logout failed"))
-        }
+  }
+
+  // MARK: - Navigation
+
+  func navigateToHome() {
+    showHome()
+  }
+
+  func navigateToMyBenevits() {
+    homeViewModel.loadMockBenevits()
+    showHome()
+  }
+
+  // MARK: - Session
+
+  func logout() {
+    do {
+      try Auth.auth().signOut()
+      showLauncher()
+    } catch {
+      AppErrorManager.shared.present(error: .server(message: "Logout failed"))
     }
-    
-    func navigateToMyBenevits() {
-        homeViewModel.loadMockBenevits()
-        showHome()
-    }
-    
+  }
+
+  // MARK: - Private Helpers
+
+  private func showLauncher() {
+    rootView = AnyView(LaunchScreenView())
+  }
+
+  private func showHome() {
+    let view = HomeView(viewModel: homeViewModel)
+      .environmentObject(self)
+    rootView = AnyView(view)
+  }
 }

--- a/SocioInfonavitApp/SocioInfonavitApp/App/AppDelegate.swift
+++ b/SocioInfonavitApp/SocioInfonavitApp/App/AppDelegate.swift
@@ -9,6 +9,9 @@ import FirebaseCore
 import UIKit
 
 class AppDelegate: NSObject, UIApplicationDelegate {
+
+  // MARK: - UIApplicationDelegate
+
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil

--- a/SocioInfonavitApp/SocioInfonavitApp/App/SocioInfonavitApp.swift
+++ b/SocioInfonavitApp/SocioInfonavitApp/App/SocioInfonavitApp.swift
@@ -10,8 +10,13 @@ import SwiftUI
 
 @main
 struct SocioInfonavitApp: App {
+
+  // MARK: - Properties
+
   @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
   @StateObject private var coordinator = AppCoordinator()
+
+  // MARK: - Scene
 
   var body: some Scene {
     WindowGroup {

--- a/SocioInfonavitApp/SocioInfonavitApp/Features/Home/HomeView.swift
+++ b/SocioInfonavitApp/SocioInfonavitApp/Features/Home/HomeView.swift
@@ -8,10 +8,15 @@
 import SwiftUI
 
 struct HomeView: View {
+
+    // MARK: - Properties
+
     @ObservedObject var viewModel: HomeViewModel
     @State private var isMenuOpen = false
     @EnvironmentObject var coordinator: AppCoordinator
-    
+
+    // MARK: - View
+
     var body: some View {
         SideMenuContainer(
             isOpen: $isMenuOpen,


### PR DESCRIPTION
## Summary
- organize AppCoordinator with explicit sections for lifecycle, navigation, and helpers using // MARK: annotations
- add structure markers to the main App and AppDelegate for clearer responsibilities
- document HomeView properties and body with // MARK: comments to enhance readability

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68ded899338c8324bdb3fe03652179a0